### PR TITLE
Set link text to display none, fixes #8

### DIFF
--- a/src/components/Footer/styles.js
+++ b/src/components/Footer/styles.js
@@ -33,7 +33,7 @@ export const SocialMediaIcon = styled.a`
   }
 
   span {
-    visibility: hidden;
+    display: none;
   }
 
   ${media.small``};


### PR DESCRIPTION
The cause for the overflow was due to:

![image](https://user-images.githubusercontent.com/10349496/47294115-ab984680-d63e-11e8-83a7-f01a8c8681b4.png)

The link text on the `span` was set to `visibility: hidden`, which still takes up space.
Setting it to `display: none` should be the proper fix.

With this fix, we don't need to have specific `width` and `height` for the svg icons.

Please take a look @Asjas!